### PR TITLE
Always remove setLocalStorage from URL

### DIFF
--- a/src/react/SkillPage/SkillPageContainer.jsx
+++ b/src/react/SkillPage/SkillPageContainer.jsx
@@ -100,9 +100,11 @@ export default function SkillPageContainer(props) {
   useEffect(() => {
     const gsvId = query.setLocalStorage;
 
-    if (gsvId && version === CURRENT_VERSION) {
-      localStorage.setItem("gsvId", gsvId);
-      localStorage.setItem("gsvName", data.user.playerName);
+    if (gsvId) {
+      if (version === CURRENT_VERSION) {
+        localStorage.setItem("gsvId", gsvId);
+        localStorage.setItem("gsvName", data.user.playerName);
+      }
       window.history.pushState("", "", window.location.href.split("?")[0]);
     }
   }, []);


### PR DESCRIPTION
Currently setLocalStorage is only removed from the URL if you load skill for the current version.

This PR always removes setLocalStorage from the URL if it's present.